### PR TITLE
Fix supabase import paths

### DIFF
--- a/src/components/ai-news/hooks/useNewsOperations.ts
+++ b/src/components/ai-news/hooks/useNewsOperations.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { supabase } from "@/integrations/supabase/client";
+import { supabase } from "@/lib/supabaseClient";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "@/components/ui/use-toast";
 

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,6 +1,6 @@
 import { Auth } from "@supabase/auth-ui-react";
 import { ThemeSupa } from "@supabase/auth-ui-shared";
-import { supabase } from "@/integrations/supabase/client";
+import { supabase } from "@/lib/supabaseClient";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Card } from "@/components/ui/card";
 

--- a/src/components/crm/ClientDetails.tsx
+++ b/src/components/crm/ClientDetails.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams, Navigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabaseClient';
 import { Contact } from './client-details/ContactInfoCard';
 import { useClientUpdate } from './client-details/useClientUpdate';
 import { useClientInitialization } from './client-details/useClientInitialization';

--- a/src/components/crm/business-summary/BusinessSummary.tsx
+++ b/src/components/crm/business-summary/BusinessSummary.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabaseClient';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
 import {

--- a/src/components/crm/client-details/AdditionalInfoCard.tsx
+++ b/src/components/crm/client-details/AdditionalInfoCard.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Edit2, Save } from 'lucide-react';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabaseClient';
 import { toast } from '@/components/ui/use-toast';
 
 interface AdditionalInfoCardProps {

--- a/src/components/crm/client-details/ClientContent.tsx
+++ b/src/components/crm/client-details/ClientContent.tsx
@@ -7,7 +7,7 @@ import { ContactInfoCard } from './ContactInfoCard';
 import { StatusTab } from './StatusTab';
 import { TaskHistory } from './TaskHistory';
 import { UpdateNextStepButton } from './components/UpdateNextStepButton';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabaseClient';
 import { BackgroundSection } from './sections/BackgroundSection';
 import { DueItemsSection } from './sections/DueItemsSection';
 import { useRevenueCalculations } from './hooks/useRevenueCalculations';

--- a/src/components/crm/client-details/NextStepsHistory.tsx
+++ b/src/components/crm/client-details/NextStepsHistory.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabaseClient';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { format } from 'date-fns';
 import { Card } from '@/components/ui/card';

--- a/src/components/crm/client-details/StatusTab.tsx
+++ b/src/components/crm/client-details/StatusTab.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabaseClient';
 import { useToast } from '@/hooks/use-toast';
 import { useQuery } from '@tanstack/react-query';
 import { StatusForm } from './status/StatusForm';

--- a/src/components/crm/client-details/TaskHistory.tsx
+++ b/src/components/crm/client-details/TaskHistory.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabaseClient';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { format } from 'date-fns';
 import { Card } from '@/components/ui/card';

--- a/src/components/crm/client-details/components/RecommendationAlert.tsx
+++ b/src/components/crm/client-details/components/RecommendationAlert.tsx
@@ -6,7 +6,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Switch } from "@/components/ui/switch";
 import { format } from "date-fns";
 import { useState } from "react";
-import { supabase } from "@/integrations/supabase/client";
+import { supabase } from "@/lib/supabaseClient";
 import { toast } from "@/components/ui/use-toast";
 
 interface RecommendationAlertProps {

--- a/src/components/crm/client-details/components/UpdateNextStepButton.tsx
+++ b/src/components/crm/client-details/components/UpdateNextStepButton.tsx
@@ -5,7 +5,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Label } from "@/components/ui/label";
 import { Calendar } from 'lucide-react';
 import { Input } from "@/components/ui/input";
-import { supabase } from "@/lib/supabase";
+import { supabase } from "@/lib/supabaseClient";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "@/components/ui/use-toast";
 import { Switch } from "@/components/ui/switch";

--- a/src/components/crm/client-details/components/UrgentFlagToggle.tsx
+++ b/src/components/crm/client-details/components/UrgentFlagToggle.tsx
@@ -1,7 +1,7 @@
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { AlertTriangle } from 'lucide-react';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabaseClient';
 import { toast } from '@/components/ui/use-toast';
 import { useQueryClient } from '@tanstack/react-query';
 

--- a/src/components/crm/client-details/hooks/useClientData.ts
+++ b/src/components/crm/client-details/hooks/useClientData.ts
@@ -1,6 +1,6 @@
 
 import { useQuery } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabaseClient';
 import { queryKeys } from '@/lib/queryKeys';
 
 export const useClientData = (clientId: number) => {

--- a/src/components/crm/client-details/hooks/useRecommendations.ts
+++ b/src/components/crm/client-details/hooks/useRecommendations.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabaseClient';
 import { toast } from '@/components/ui/use-toast';
 
 interface ClientAnalysisData {

--- a/src/components/crm/client-details/metrics/DealLikelihood.tsx
+++ b/src/components/crm/client-details/metrics/DealLikelihood.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { supabase } from "@/integrations/supabase/client";
+import { supabase } from "@/lib/supabaseClient";
 import { toast } from "@/components/ui/use-toast";
 import { useQueryClient } from '@tanstack/react-query';
 

--- a/src/components/crm/client-details/metrics/ForecastEditor.tsx
+++ b/src/components/crm/client-details/metrics/ForecastEditor.tsx
@@ -7,7 +7,7 @@ import { Card } from '@/components/ui/card';
 import { useClientForecasts } from '@/hooks/useClientForecasts';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabaseClient';
 
 interface ForecastEditorProps {
   clientId: number;

--- a/src/components/crm/client-details/sections/BackgroundSection.tsx
+++ b/src/components/crm/client-details/sections/BackgroundSection.tsx
@@ -3,7 +3,7 @@ import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Edit2, Save } from 'lucide-react';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabaseClient';
 import { toast } from '@/components/ui/use-toast';
 import { useQueryClient } from '@tanstack/react-query';
 

--- a/src/components/crm/client-details/useClientUpdate.ts
+++ b/src/components/crm/client-details/useClientUpdate.ts
@@ -1,6 +1,6 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/lib/supabase';
+import { supabase } from '@/lib/supabaseClient';
 import { toast } from '@/components/ui/use-toast';
 import { Contact } from './ContactInfoCard';
 

--- a/src/components/crm/client-form/hooks/useClientMutation.ts
+++ b/src/components/crm/client-form/hooks/useClientMutation.ts
@@ -1,7 +1,7 @@
 
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { supabase } from '@/lib/supabase';
+import { supabase } from '@/lib/supabaseClient';
 import { useQueryClient } from '@tanstack/react-query';
 import { ClientFormData } from '../types';
 import { toast } from '@/components/ui/use-toast';

--- a/src/components/crm/client-search/ClientSearch.tsx
+++ b/src/components/crm/client-search/ClientSearch.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Search } from 'lucide-react';
 import { useToast } from '@/components/ui/use-toast';
-import { supabase } from '@/lib/supabase';
+import { supabase } from '@/lib/supabaseClient';
 
 export const ClientSearch = () => {
   const navigate = useNavigate();

--- a/src/components/crm/intel-search/useIntelSearch.ts
+++ b/src/components/crm/intel-search/useIntelSearch.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
+import { supabase } from "@/lib/supabaseClient";
 
 export const useIntelSearch = (query: string) => {
   return useQuery({

--- a/src/components/crm/priority-actions/TaskForm.tsx
+++ b/src/components/crm/priority-actions/TaskForm.tsx
@@ -6,7 +6,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabaseClient';
 import { useToast } from '@/components/ui/use-toast';
 import { useTaskMutations } from './hooks/useTaskMutations';
 import { Task } from '@/hooks/useTaskDeletion';

--- a/src/components/crm/priority-actions/hooks/taskTypes.ts
+++ b/src/components/crm/priority-actions/hooks/taskTypes.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/lib/supabase';
+import { supabase } from '@/lib/supabaseClient';
 import { TaskType } from '@/types/task';
 
 export { TaskType } from '@/types/task';

--- a/src/components/crm/priority-actions/hooks/useCompletionStatus.ts
+++ b/src/components/crm/priority-actions/hooks/useCompletionStatus.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/lib/supabase';
+import { supabase } from '@/lib/supabaseClient';
 import { toast } from '@/hooks/use-toast';
 import { PriorityItem } from './usePriorityData';
 import { useQueryCacheManager } from './useQueryCacheManager';

--- a/src/components/crm/priority-actions/hooks/usePriorityData.ts
+++ b/src/components/crm/priority-actions/hooks/usePriorityData.ts
@@ -1,7 +1,7 @@
 
 import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { supabase, logResponse } from "@/lib/supabase";
+import { supabase, logResponse } from "@/lib/supabaseClient";
 import { PriorityItem } from "./taskTypes";
 import { queryKeys } from "@/lib/queryKeys";
 

--- a/src/components/crm/priority-actions/hooks/useTasksMutations.ts
+++ b/src/components/crm/priority-actions/hooks/useTasksMutations.ts
@@ -2,7 +2,7 @@
 import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Task, tasksTable } from './taskTypes';
-import { supabase, logQuery } from '@/lib/supabase';
+import { supabase, logQuery } from '@/lib/supabaseClient';
 import { toast } from '@/hooks/use-toast';
 
 export const useTasksMutations = () => {

--- a/src/components/crm/priority-actions/hooks/useTasksQuery.ts
+++ b/src/components/crm/priority-actions/hooks/useTasksQuery.ts
@@ -1,7 +1,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { Task, tasksTable } from './taskTypes';
-import { supabase, logQuery } from '@/lib/supabase';
+import { supabase, logQuery } from '@/lib/supabaseClient';
 import { toast } from '@/hooks/use-toast';
 
 export const useTasksQuery = (category?: string, showCompleted = false) => {

--- a/src/components/crm/priority-actions/hooks/useUrgencyStatus.ts
+++ b/src/components/crm/priority-actions/hooks/useUrgencyStatus.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/lib/supabase';
+import { supabase } from '@/lib/supabaseClient';
 import { toast } from '@/hooks/use-toast';
 import { PriorityItem } from './usePriorityData';
 import { useQueryCacheManager } from './useQueryCacheManager';

--- a/src/components/crm/revenue-summary/RevenueSummary.tsx
+++ b/src/components/crm/revenue-summary/RevenueSummary.tsx
@@ -1,7 +1,7 @@
 
 import { useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client'; 
+import { supabase } from '@/lib/supabaseClient'; 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { RevenueStats } from './components/RevenueStats';

--- a/src/components/debug/TaskDebugPanel.tsx
+++ b/src/components/debug/TaskDebugPanel.tsx
@@ -5,7 +5,7 @@ import { useTaskData } from '@/components/crm/priority-actions/hooks/useTaskData
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Database, Bug, X } from 'lucide-react';
-import { supabase } from '@/lib/supabase';
+import { supabase } from '@/lib/supabaseClient';
 
 export const TaskDebugPanel = () => {
   const [isOpen, setIsOpen] = useState(false);

--- a/src/components/strategy/TaskList.tsx
+++ b/src/components/strategy/TaskList.tsx
@@ -5,7 +5,7 @@ import { NextStepItem } from "../crm/priority-actions/NextStepItem";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { supabase } from "@/lib/supabase";
+import { supabase } from "@/lib/supabaseClient";
 import { toast } from "@/hooks/use-toast";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { Trash2, RefreshCw } from "lucide-react";

--- a/src/components/strategy/hooks/useGeneralTasks.ts
+++ b/src/components/strategy/hooks/useGeneralTasks.ts
@@ -1,6 +1,6 @@
 
 import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
+import { supabase } from "@/lib/supabaseClient";
 import { Task } from "@/hooks/useTaskDeletion";
 import { queryKeys } from "@/lib/queryKeys";
 

--- a/src/components/strategy/hooks/useIdeaGeneration.ts
+++ b/src/components/strategy/hooks/useIdeaGeneration.ts
@@ -1,7 +1,7 @@
 
 import { useState } from "react";
 import { toast } from "@/components/ui/use-toast";
-import { supabase } from "@/integrations/supabase/client";
+import { supabase } from "@/lib/supabaseClient";
 
 export const useIdeaGeneration = (category: string, onIdeasGenerated: () => void) => {
   const [isGenerating, setIsGenerating] = useState(false);

--- a/src/components/ui/main-nav.tsx
+++ b/src/components/ui/main-nav.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Users, PlusCircle } from "lucide-react";
 import { ClientListSection } from "@/components/crm/dashboard/ClientListSection";
 import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
+import { supabase } from "@/lib/supabaseClient";
 import { ThemeToggle } from "./theme-toggle";
 
 export function MainNav() {

--- a/src/hooks/useClientForecasts.ts
+++ b/src/hooks/useClientForecasts.ts
@@ -1,6 +1,6 @@
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabaseClient';
 import { MonthlyForecast, ForecastUpdate } from '@/types/forecast';
 import { format, parseISO } from 'date-fns';
 import { toast } from '@/components/ui/use-toast';

--- a/src/integrations/google/calendar.ts
+++ b/src/integrations/google/calendar.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabaseClient';
 import { CalendarEventInsert, CalendarEventRow } from '@/integrations/supabase/types/calendar-events.types';
 import logger from '@/utils/logger';
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,7 +3,7 @@ import { MainNav } from "@/components/ui/main-nav";
 import { PriorityActions } from "@/components/crm/priority-actions/PriorityActions";
 import { RevenueSummary } from "@/components/crm/revenue-summary/RevenueSummary";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { supabase } from "@/lib/supabase";
+import { supabase } from "@/lib/supabaseClient";
 import { TaskDialog } from "@/components/crm/priority-actions/TaskDialog";
 import { DashboardHeader } from "@/components/crm/dashboard/DashboardHeader";
 import { SearchSection } from "@/components/crm/dashboard/SearchSection";


### PR DESCRIPTION
## Summary
- switch remaining components to use `@/lib/supabaseClient`
- enforce email domain check when reloading authenticated sessions

## Testing
- `npm run build` *(fails: `vite: not found`)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*