### PR TITLE
Refactor priority task system to use unified task type

### DIFF
--- a/src/components/crm/priority-actions/GeneralTaskItem.tsx
+++ b/src/components/crm/priority-actions/GeneralTaskItem.tsx
@@ -1,9 +1,7 @@
 import { cn } from "@/lib/utils";
-import { Tables } from "@/integrations/supabase/types";
+import { Task } from '@/types/task';
 
-type GeneralTaskRow = Tables<'general_tasks'>;
-
-const getCategoryColor = (task: GeneralTaskRow, isClientTask: boolean) => {
+const getCategoryColor = (task: Task, isClientTask: boolean) => {
   if (isClientTask || task.client_id) {
     return 'bg-[#FEC6A1]/50 hover:bg-[#FEC6A1]/70';
   }
@@ -29,19 +27,20 @@ const getCategoryColor = (task: GeneralTaskRow, isClientTask: boolean) => {
   return 'bg-gray-50 hover:bg-gray-100';
 };
 
-export const GeneralTaskItem = ({ task, isClientTask = false }: { task: GeneralTaskRow; isClientTask?: boolean }) => {
+export const GeneralTaskItem = ({ task, isClientTask = false }: { task: Task; isClientTask?: boolean }) => {
   const colorClasses = getCategoryColor(task, isClientTask);
-  
+
   const titleMatch = task.title.match(/Strategic Recommendation for (.+)/);
   const displayTitle = titleMatch ? `${titleMatch[1]} Strategic Recommendation` : task.title;
-  
+
   let displayDescription = task.description || 'No description provided';
   if (titleMatch && displayDescription.includes('Type:')) {
     const [metadata, ...contentParts] = displayDescription.split('\n\n');
     displayDescription = contentParts.join('\n\n');
   }
 
-  const isOverdue = task.next_due_date ? new Date(task.next_due_date) < new Date() : false;
+  const dueDate = task.next_due_date || task.due_date;
+  const isOverdue = dueDate ? new Date(dueDate) < new Date() : false;
 
   return (
     <div className={cn(
@@ -53,16 +52,16 @@ export const GeneralTaskItem = ({ task, isClientTask = false }: { task: GeneralT
         <div className="flex-1">
           <h3 className="font-medium text-gray-900 mb-2">{displayTitle}</h3>
           <p className="text-sm text-gray-600 whitespace-pre-wrap leading-relaxed">{displayDescription}</p>
-          {task.next_due_date && (
+          {dueDate && (
             <p className={cn(
               "mt-3 text-sm flex items-center",
               isOverdue ? "text-red-600 font-medium" : "text-gray-500"
             )}>
-              Due: {new Date(task.next_due_date).toLocaleDateString()}
+              Due: {new Date(dueDate).toLocaleDateString()}
             </p>
           )}
         </div>
-        {task.urgent && (
+        {(task.urgent ?? false) && (
           <span className="px-3 py-1 text-xs font-medium text-red-700 bg-red-100 rounded-full shrink-0">
             Urgent
           </span>

--- a/src/components/crm/priority-actions/PriorityActionItem.tsx
+++ b/src/components/crm/priority-actions/PriorityActionItem.tsx
@@ -1,31 +1,31 @@
 
 import { Link } from 'react-router-dom';
 import { Calendar, AlertCircle } from 'lucide-react';
-import { PriorityItem } from './hooks/usePriorityData';
+import { Task } from '@/types/task';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 
 interface PriorityActionItemProps {
-  item: PriorityItem;
+  item: Task;
   onUrgentChange: (checked: boolean) => void;
 }
 
 export const PriorityActionItem = ({ item, onUrgentChange }: PriorityActionItemProps) => {
   // Get title from task data
-  const title = item.data.title || (item.data.notes || 'No details');
-  
+  const title = item.title || item.notes || 'No details';
+
   // Get description from task data
-  const description = item.data.description || '';
-  
+  const description = item.description || '';
+
   // Get client name if available
-  const clientName = item.data.client?.name || item.data.client_name || null;
-  
+  const clientName = item.client?.name || item.client_name || null;
+
   // Get due date
-  const dueDate = item.data.due_date || item.data.next_due_date || null;
-  
+  const dueDate = item.due_date || item.next_due_date || null;
+
   // Get urgent status
-  const urgent = item.data.urgent || false;
+  const urgent = item.urgent ?? item.priority === 'urgent';
   
   const toggleUrgent = () => {
     onUrgentChange(!urgent);
@@ -33,12 +33,12 @@ export const PriorityActionItem = ({ item, onUrgentChange }: PriorityActionItemP
 
   // Determine background color based on type or category
   const getBackgroundColorClass = () => {
-    if (item.data.client_id) {
+    if (item.client_id) {
       return 'bg-[#FEC6A1]/30 hover:bg-[#FEC6A1]/50';
     }
-    
-    if (item.data.category) {
-      const category = item.data.category.toLowerCase();
+
+    if (item.category) {
+      const category = item.category.toLowerCase();
       
       if (category === 'business admin') {
         return 'bg-gray-100 hover:bg-gray-200';

--- a/src/components/crm/priority-actions/PriorityItemsList.tsx
+++ b/src/components/crm/priority-actions/PriorityItemsList.tsx
@@ -1,516 +1,252 @@
 import logger from '@/utils/logger';
 
-import { useState, useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { PriorityActionItem } from './PriorityActionItem';
-import { PriorityItem } from './hooks/usePriorityData';
 import { useItemStatusChange } from './hooks/useItemStatusChange';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Button } from '@/components/ui/button';
 import { Trash2 } from 'lucide-react';
-import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog';
-import { toast } from '@/hooks/use-toast';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog';
 import { CompletionConfirmDialog } from './components/CompletionConfirmDialog';
+import { Task, TaskPriority, TaskStatus } from '@/types/task';
 
 interface PriorityItemsListProps {
-  items: PriorityItem[];
+  items: Task[];
   onItemRemoved?: () => void;
   onItemUpdated?: () => void;
-  onItemSelected?: (item: PriorityItem) => void;
+  onItemSelected?: (item: Task) => void;
   category?: string;
   showCompleted?: boolean;
 }
 
-export const PriorityItemsList = ({ 
-  items, 
-  onItemRemoved, 
+const getReopenedStatus = (status: TaskStatus): TaskStatus => {
+  if (status === 'completed') {
+    return 'incomplete';
+  }
+  return status;
+};
+
+export const PriorityItemsList = ({
+  items,
+  onItemRemoved,
   onItemUpdated,
   onItemSelected,
   category,
   showCompleted = false
-}: PriorityItemsListProps & { showCompleted?: boolean }) => {
-  const [localItems, setLocalItems] = useState<PriorityItem[]>([]);
-  const [openAlertDialogId, setOpenAlertDialogId] = useState<string | null>(null);
+}: PriorityItemsListProps) => {
+  const [localItems, setLocalItems] = useState<Task[]>([]);
+  const [itemPendingDelete, setItemPendingDelete] = useState<Task | null>(null);
+  const [itemPendingCompletion, setItemPendingCompletion] = useState<Task | null>(null);
   const [isProcessingDelete, setIsProcessingDelete] = useState(false);
   const [isProcessingUpdate, setIsProcessingUpdate] = useState(false);
-  const { handleCompletedChange, handleDelete, handleUrgentChange } = useItemStatusChange();
-  
-  const [completionConfirmItem, setCompletionConfirmItem] = useState<PriorityItem | null>(null);
-  const deletedItemIds = useRef<Set<string>>(new Set());
-  const completedItemIds = useRef<Set<string>>(new Set());
 
-  useEffect(() => {
-    deletedItemIds.current = new Set<string>();
-    completedItemIds.current = new Set<string>();
-    logger.info('Deleted and completed items sets reset on component mount');
-    
-    return () => {
-      deletedItemIds.current.clear();
-      completedItemIds.current.clear();
-      logger.info('Deleted and completed items sets cleared on component unmount');
-    };
-  }, []);
+  const { handleCompletedChange, handleUrgentChange, handleDelete } = useItemStatusChange();
+  const previousItemsRef = useRef<Task[]>([]);
 
   useEffect(() => {
     if (!items || !Array.isArray(items)) {
-      logger.info('No items received or invalid items format');
+      logger.info('PriorityItemsList received invalid items array');
       setLocalItems([]);
       return;
     }
-    
-    logger.info('PriorityItemsList received items:', items.length, items);
-    logger.info('showCompleted flag:', showCompleted);
-    logger.info('Deleted items count:', deletedItemIds.current.size);
-    logger.info('Completed items count:', completedItemIds.current.size);
-    
-    if (deletedItemIds.current.size > 0) {
-      logger.info('Currently deleted items:', [...deletedItemIds.current]);
-    }
 
-    if (completedItemIds.current.size > 0 && !showCompleted) {
-      logger.info('Currently completed items (not showing completed):', [...completedItemIds.current]);
-    }
+    logger.info('PriorityItemsList received items:', items.length);
+    const filtered = items.filter(item =>
+      showCompleted ? item.status === 'completed' : item.status !== 'completed'
+    );
 
-    const validItems = items.filter(item => {
-      if (!item || !item.data || !item.data.id) {
-        logger.info('Filtering out invalid item:', item);
-        return false;
-      }
-      
-      const uniqueId = `${item.type}-${item.data.id}`;
-      const isDeleted = deletedItemIds.current.has(uniqueId);
-      
-      if (isDeleted) {
-        logger.info(`Filtering out locally deleted item: ${uniqueId}`);
-        return false;
-      }
-      
-      // When not showing completed items, filter out items that were just marked as completed
-      if (!showCompleted && completedItemIds.current.has(uniqueId)) {
-        logger.info(`Filtering out locally completed item: ${uniqueId}`);
-        return false;
-      }
-      
-      return true;
-    });
-    
-    logger.info('PriorityItemsList filtered valid items:', validItems.length);
-
-    let filteredItems;
-    
-    if (showCompleted) {
-      filteredItems = validItems.filter(item => {
-        const isCompleted = (item.type === 'task' && item.data.status === 'completed') || 
-          (item.type === 'next_step' && item.data.completed_at !== null);
-        return isCompleted;
-      });
-      logger.info('Filtered for completed items:', filteredItems.length);
-    } else {
-      filteredItems = validItems.filter(item => {
-        const isIncomplete = (item.type === 'task' && item.data.status !== 'completed') || 
-          (item.type === 'next_step' && item.data.completed_at === null);
-        return isIncomplete;
-      });
-      logger.info('Filtered for active items:', filteredItems.length);
-    }
-    
-    setLocalItems(filteredItems);
+    setLocalItems(filtered);
   }, [items, showCompleted]);
 
-  const confirmDelete = (item: PriorityItem) => {
-    if (!item || !item.data || !item.data.id) {
-      logger.error('Invalid item for deletion:', item);
-      return;
-    }
-    setOpenAlertDialogId(item.data.id);
+  const updateLocalTask = (taskId: string, updates: Partial<Task>) => {
+    setLocalItems(prev => prev.map(task => (task.id === taskId ? { ...task, ...updates } : task)));
   };
 
-  const closeDialog = () => {
-    setOpenAlertDialogId(null);
-  };
-
-  const proceedWithDelete = async (item: PriorityItem) => {
-    if (isProcessingDelete) {
-      logger.info('Already processing a delete operation, ignoring');
-      return;
-    }
-    
-    try {
-      setIsProcessingDelete(true);
-      const itemId = item.data.id;
-      const uniqueItemId = `${item.type}-${itemId}`;
-      
-      logger.info(`Deleting item ${uniqueItemId}`);
-      
-      deletedItemIds.current.add(uniqueItemId);
-      logger.info(`Added ${uniqueItemId} to deletedItemIds set`, [...deletedItemIds.current]);
-      
-      setLocalItems(prevItems => {
-        const filtered = prevItems.filter(i => !(i.type === item.type && i.data.id === itemId));
-        logger.info(`Removed item from localItems, before: ${prevItems.length}, after: ${filtered.length}`);
-        return filtered;
-      });
-      
-      const success = await handleDelete(item);
-      
-      if (success) {
-        logger.info(`${item.type} deleted successfully:`, itemId);
-        
-        toast({
-          title: "Success",
-          description: `${item.type === 'task' ? 'Task' : 'Next step'} deleted successfully`,
-        });
-        
-        if (onItemRemoved) {
-          logger.info('Calling onItemRemoved callback');
-          onItemRemoved();
-        }
-      } else {
-        logger.error(`Failed to delete ${item.type}:`, itemId);
-        
-        toast({
-          title: "Error",
-          description: `Failed to delete ${item.type === 'task' ? 'task' : 'next step'}. The item will remain hidden until page refresh.`,
-          variant: "destructive",
-        });
-      }
-    } catch (error) {
-      logger.error('Error in deletion process:', error);
-      toast({
-        title: "Error",
-        description: "An unexpected error occurred",
-        variant: "destructive",
-      });
-    } finally {
-      setIsProcessingDelete(false);
-      closeDialog();
-    }
-  };
-
-  const handleCompletionStatusChange = async (item: PriorityItem, checked: boolean) => {
+  const processCompletionChange = async (task: Task, completed: boolean) => {
     if (isProcessingUpdate) return;
-    
-    if (checked) {
-      setCompletionConfirmItem(item);
+
+    setIsProcessingUpdate(true);
+    const previousStatus = task.status;
+    const newStatus: TaskStatus = completed ? 'completed' : getReopenedStatus(previousStatus);
+
+    logger.info('Processing completion change', { taskId: task.id, completed });
+
+    updateLocalTask(task.id, { status: newStatus });
+
+    if (!showCompleted && completed) {
+      setLocalItems(prev => prev.filter(item => item.id !== task.id));
+    }
+
+    const success = await handleCompletedChange({ ...task, status: newStatus }, completed);
+
+    if (!success) {
+      logger.info('Completion update failed, reverting local state');
+      updateLocalTask(task.id, { status: previousStatus });
+
+      if (!showCompleted && completed) {
+        setLocalItems(prev => [...prev, task]);
+      }
     } else {
-      processCompletionChange(item, checked);
+      onItemUpdated?.();
+    }
+
+    setIsProcessingUpdate(false);
+  };
+
+  const handleCompletionToggle = (task: Task, completed: boolean) => {
+    if (completed) {
+      setItemPendingCompletion(task);
+    } else {
+      processCompletionChange(task, completed);
     }
   };
 
-  const processCompletionChange = async (item: PriorityItem, checked: boolean) => {
+  const handleUrgentToggle = async (task: Task, checked: boolean) => {
     if (isProcessingUpdate) return;
-    
-    try {
-      setIsProcessingUpdate(true);
-      const itemId = item.data.id;
-      const uniqueItemId = `${item.type}-${itemId}`;
-      
-      if (checked && !showCompleted) {
-        // Add to completed items set when marking as complete
-        completedItemIds.current.add(uniqueItemId);
-        logger.info(`Added ${uniqueItemId} to completedItemIds set`, [...completedItemIds.current]);
-        
-        // Immediately remove from local list if not showing completed items
-        setLocalItems(prevItems => prevItems.filter(i => 
-          !(i.type === item.type && i.data.id === itemId)
-        ));
-      } else {
-        // Remove from completed items set when marking as incomplete
-        completedItemIds.current.delete(uniqueItemId);
-        
-        // Update local state for the item status
-        if (item.type === 'task') {
-          setLocalItems(prevItems => 
-            prevItems.map(i => {
-              if (i.type === 'task' && i.data.id === item.data.id) {
-                return {
-                  ...i,
-                  data: {
-                    ...i.data,
-                    status: checked ? 'completed' : 'incomplete'
-                  }
-                } as PriorityItem;
-              }
-              return i;
-            })
-          );
-        } else if (item.type === 'next_step') {
-          setLocalItems(prevItems => 
-            prevItems.map(i => {
-              if (i.type === 'next_step' && i.data.id === item.data.id) {
-                return {
-                  ...i,
-                  data: {
-                    ...i.data,
-                    completed_at: checked ? new Date().toISOString() : null
-                  }
-                } as PriorityItem;
-              }
-              return i;
-            })
-          );
-        }
-      }
-      
-      // Update in the database
-      const success = await handleCompletedChange(item, checked);
-      
-      if (success) {
-        logger.info(`Task ${uniqueItemId} ${checked ? 'completed' : 'marked active'} successfully`);
-        toast({
-          title: "Success",
-          description: `${item.type === 'task' ? 'Task' : 'Next step'} marked as ${checked ? 'completed' : 'active'}`,
-        });
-        if (onItemUpdated) {
-          onItemUpdated();
-        }
-      } else {
-        logger.error(`Failed to update completion status for ${uniqueItemId}`);
-        
-        // Revert the local changes if the API call failed
-        if (checked) {
-          completedItemIds.current.delete(uniqueItemId);
-        }
-        
-        if (item.type === 'task') {
-          setLocalItems(prevItems => 
-            prevItems.map(i => {
-              if (i.type === 'task' && i.data.id === item.data.id) {
-                return {
-                  ...i,
-                  data: {
-                    ...i.data,
-                    status: checked ? 'incomplete' : 'completed'
-                  }
-                } as PriorityItem;
-              }
-              return i;
-            })
-          );
-        } else if (item.type === 'next_step') {
-          setLocalItems(prevItems => 
-            prevItems.map(i => {
-              if (i.type === 'next_step' && i.data.id === item.data.id) {
-                return {
-                  ...i,
-                  data: {
-                    ...i.data,
-                    completed_at: checked ? null : new Date().toISOString()
-                  }
-                } as PriorityItem;
-              }
-              return i;
-            })
-          );
-        }
-      }
-    } catch (error) {
-      logger.error('Error handling completion status change:', error);
-    } finally {
-      setIsProcessingUpdate(false);
+
+    setIsProcessingUpdate(true);
+    const previousUrgent = task.urgent ?? false;
+    const previousPriority = task.priority;
+    const updatedPriority: TaskPriority = checked
+      ? 'urgent'
+      : previousPriority === 'urgent'
+        ? 'normal'
+        : previousPriority;
+
+    updateLocalTask(task.id, { urgent: checked, priority: updatedPriority });
+
+    const success = await handleUrgentChange(task, checked);
+    if (!success) {
+      logger.info('Urgent update failed, reverting local state');
+      updateLocalTask(task.id, { urgent: previousUrgent, priority: previousPriority });
+    } else {
+      onItemUpdated?.();
     }
+
+    setIsProcessingUpdate(false);
   };
 
-  const handleUrgentStatusChange = (item: PriorityItem, checked: boolean) => {
-    if (isProcessingUpdate) return;
-    
-    try {
-      setIsProcessingUpdate(true);
-      
-      if (item.type === 'task') {
-        setLocalItems(prevItems => 
-          prevItems.map(i => {
-            if (i.type === 'task' && i.data.id === item.data.id) {
-              return {
-                ...i,
-                data: {
-                  ...i.data,
-                  urgent: checked
-                }
-              } as PriorityItem;
-            }
-            return i;
-          })
-        );
-      } else if (item.type === 'next_step') {
-        setLocalItems(prevItems => 
-          prevItems.map(i => {
-            if (i.type === 'next_step' && i.data.id === item.data.id) {
-              return {
-                ...i,
-                data: {
-                  ...i.data,
-                  urgent: checked
-                }
-              } as PriorityItem;
-            }
-            return i;
-          })
-        );
-      }
-      
-      handleUrgentChange(item, checked)
-        .then(success => {
-          if (success) {
-            logger.info('Urgent status updated successfully');
-            if (onItemUpdated) {
-              onItemUpdated();
-            }
-          } else {
-            logger.error('Failed to update urgent status');
-            if (item.type === 'task') {
-              setLocalItems(prevItems => 
-                prevItems.map(i => {
-                  if (i.type === 'task' && i.data.id === item.data.id) {
-                    return {
-                      ...i,
-                      data: {
-                        ...i.data,
-                        urgent: !checked
-                      }
-                    } as PriorityItem;
-                  }
-                  return i;
-                })
-              );
-            } else if (item.type === 'next_step') {
-              setLocalItems(prevItems => 
-                prevItems.map(i => {
-                  if (i.type === 'next_step' && i.data.id === item.data.id) {
-                    return {
-                      ...i,
-                      data: {
-                        ...i.data,
-                        urgent: !checked
-                      }
-                    } as PriorityItem;
-                  }
-                  return i;
-                })
-              );
-            }
-          }
-          setIsProcessingUpdate(false);
-        })
-        .catch(error => {
-          logger.error('Error in handleUrgentChange:', error);
-          setIsProcessingUpdate(false);
-        });
-    } catch (error) {
-      logger.error('Error setting up urgent status change:', error);
-      setIsProcessingUpdate(false);
-    }
+  const confirmDelete = (task: Task) => {
+    setItemPendingDelete(task);
   };
 
-  const handleItemClick = (item: PriorityItem) => {
-    if (onItemSelected) {
-      onItemSelected(item);
-    }
+  const closeDeleteDialog = () => {
+    setItemPendingDelete(null);
   };
+
+  const proceedWithDelete = async () => {
+    if (!itemPendingDelete) return;
+
+    if (isProcessingDelete) {
+      logger.info('Already processing a delete request, ignoring');
+      return;
+    }
+
+    setIsProcessingDelete(true);
+    previousItemsRef.current = localItems;
+    setLocalItems(prev => prev.filter(item => item.id !== itemPendingDelete.id));
+
+    const success = await handleDelete(itemPendingDelete);
+    if (!success) {
+      logger.info('Delete failed, restoring previous items');
+      setLocalItems(previousItemsRef.current);
+    } else {
+      onItemRemoved?.();
+    }
+
+    setIsProcessingDelete(false);
+    setItemPendingDelete(null);
+  };
+
+  const renderEmptyState = () => (
+    <div className="p-4 text-center text-gray-500">
+      No {showCompleted ? 'completed' : 'priority'} items found{category ? ` for category: ${category}` : ''}.
+      {!showCompleted && (
+        <div className="mt-2">
+          <p>Try switching to the "Completed" tab to see completed items.</p>
+        </div>
+      )}
+    </div>
+  );
 
   if (!localItems.length) {
-    return (
-      <div className="p-4 text-center text-gray-500">
-        No {showCompleted ? "completed" : "priority"} items found{category ? ` for category: ${category}` : ''}.
-        {!showCompleted && (
-          <div className="mt-2">
-            <p>Try switching to the "Completed" tab to see completed items.</p>
-          </div>
-        )}
-      </div>
-    );
+    return renderEmptyState();
   }
 
   return (
     <div className="space-y-2">
-      {localItems.map((item) => {
-        const itemId = item.data.id;
-        const uniqueItemId = `${item.type}-${itemId}`;
-        
-        if (deletedItemIds.current.has(uniqueItemId)) {
-          logger.info(`Skipping rendering of deleted item ${uniqueItemId}`);
-          return null;
-        }
-        
-        return (
-          <div 
-            key={uniqueItemId} 
-            className="flex items-start gap-2 p-2 border rounded-lg hover:bg-gray-50 cursor-pointer"
-            onClick={() => onItemSelected && onItemSelected(item)}
-          >
-            <div className="pt-1" onClick={(e) => e.stopPropagation()}>
-              <Checkbox 
-                checked={
-                  item.type === 'task' 
-                    ? item.data.status === 'completed' 
-                    : item.data.completed_at !== null
-                } 
-                onCheckedChange={(checked) => {
-                  if (handleCompletionStatusChange) {
-                    handleCompletionStatusChange(item, checked as boolean);
-                  }
-                }}
-                disabled={isProcessingUpdate}
-              />
-            </div>
-            
-            <div className="flex-1" onClick={(e) => e.stopPropagation()}>
-              <PriorityActionItem 
-                item={item} 
-                onUrgentChange={(checked) => {
-                  handleUrgentStatusChange(item, checked);
-                }}
-              />
-            </div>
-            
-            <Button 
-              variant="ghost" 
-              size="sm" 
-              onClick={(e) => {
-                e.stopPropagation();
-                confirmDelete(item);
-              }}
-              disabled={isProcessingDelete}
-            >
-              <Trash2 className="h-4 w-4 text-gray-500 hover:text-red-500" />
-            </Button>
-            
-            <AlertDialog open={openAlertDialogId === itemId}>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Are you sure?</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    This will permanently delete this {item.type === 'task' ? 'task' : 'next step'}.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel onClick={closeDialog}>Cancel</AlertDialogCancel>
-                  <AlertDialogAction 
-                    onClick={() => proceedWithDelete(item)}
-                    disabled={isProcessingDelete}
-                  >
-                    {isProcessingDelete ? 'Deleting...' : 'Delete'}
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
+      {localItems.map(task => (
+        <div
+          key={task.id}
+          className="flex items-start gap-2 p-2 border rounded-lg hover:bg-gray-50 cursor-pointer group"
+          onClick={() => onItemSelected?.(task)}
+        >
+          <div className="pt-1" onClick={event => event.stopPropagation()}>
+            <Checkbox
+              checked={task.status === 'completed'}
+              onCheckedChange={checked => handleCompletionToggle(task, Boolean(checked))}
+              disabled={isProcessingUpdate}
+            />
           </div>
-        );
-      })}
 
-      {completionConfirmItem && (
+          <div className="flex-1" onClick={event => event.stopPropagation()}>
+            <PriorityActionItem
+              item={task}
+              onUrgentChange={checked => handleUrgentToggle(task, checked)}
+            />
+          </div>
+
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={event => {
+              event.stopPropagation();
+              confirmDelete(task);
+            }}
+            disabled={isProcessingDelete}
+          >
+            <Trash2 className="h-4 w-4 text-gray-500 hover:text-red-500" />
+          </Button>
+        </div>
+      ))}
+
+      <AlertDialog open={!!itemPendingDelete} onOpenChange={open => !open && closeDeleteDialog()}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone. This will permanently delete the task.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={closeDeleteDialog}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={proceedWithDelete} disabled={isProcessingDelete}>
+              {isProcessingDelete ? 'Deleting...' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {itemPendingCompletion && (
         <CompletionConfirmDialog
-          open={!!completionConfirmItem}
-          onOpenChange={(open) => {
-            if (!open) setCompletionConfirmItem(null);
+          open={!!itemPendingCompletion}
+          onOpenChange={open => {
+            if (!open) setItemPendingCompletion(null);
           }}
           onConfirm={() => {
-            const item = completionConfirmItem;
-            setCompletionConfirmItem(null);
-            if (processCompletionChange) {
-              processCompletionChange(item, true);
-            }
+            const task = itemPendingCompletion;
+            setItemPendingCompletion(null);
+            processCompletionChange(task, true);
           }}
-          itemType={completionConfirmItem.type}
         />
       )}
     </div>

--- a/src/components/crm/priority-actions/components/CompletionConfirmDialog.tsx
+++ b/src/components/crm/priority-actions/components/CompletionConfirmDialog.tsx
@@ -14,14 +14,12 @@ interface CompletionConfirmDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onConfirm: () => void;
-  itemType: 'task' | 'next_step';
 }
 
-export const CompletionConfirmDialog = ({ 
-  open, 
-  onOpenChange, 
-  onConfirm, 
-  itemType 
+export const CompletionConfirmDialog = ({
+  open,
+  onOpenChange,
+  onConfirm
 }: CompletionConfirmDialogProps) => {
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
@@ -29,8 +27,7 @@ export const CompletionConfirmDialog = ({
         <AlertDialogHeader>
           <AlertDialogTitle>Mark as completed?</AlertDialogTitle>
           <AlertDialogDescription>
-            Are you sure you want to mark this {itemType === 'task' ? 'task' : 'next step'} as completed?
-            It will be moved to the completed items list.
+            Are you sure you want to mark this task as completed? It will be moved to the completed items list.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/src/components/crm/priority-actions/components/CompletionDialog.tsx
+++ b/src/components/crm/priority-actions/components/CompletionDialog.tsx
@@ -8,12 +8,12 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { PriorityItem } from "../hooks/usePriorityData";
+import { Task } from "@/types/task";
 
 interface CompletionDialogProps {
-  itemToComplete: PriorityItem | null;
+  itemToComplete: Task | null;
   onOpenChange: (open: boolean) => void;
-  onComplete: (item: PriorityItem) => void;
+  onComplete: (item: Task) => void;
 }
 
 export const CompletionDialog = ({

--- a/src/components/crm/priority-actions/components/ItemControls.tsx
+++ b/src/components/crm/priority-actions/components/ItemControls.tsx
@@ -1,11 +1,11 @@
 
 import { CheckCircle2, AlertCircle, XCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { PriorityItem } from '../hooks/usePriorityData';
+import { Task } from '@/types/task';
 import { cn } from '@/lib/utils';
 
 interface ItemControlsProps {
-  item: PriorityItem;
+  item: Task;
   onComplete: () => void;
   onUrgentChange: (checked: boolean) => void;
   onDelete: () => void;
@@ -17,8 +17,8 @@ export const ItemControls = ({
   onUrgentChange, 
   onDelete 
 }: ItemControlsProps) => {
-  const taskIsCompleted = item.data.status === 'completed';
-  const urgent = item.data.urgent || false;
+  const taskIsCompleted = item.status === 'completed';
+  const urgent = item.urgent ?? item.priority === 'urgent';
 
   const handleUrgentToggle = (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/src/components/crm/priority-actions/components/PriorityListItem.tsx
+++ b/src/components/crm/priority-actions/components/PriorityListItem.tsx
@@ -1,13 +1,12 @@
 
 import { useEffect, useState } from 'react';
-import { PriorityItem } from '../hooks/usePriorityData';
 import { GeneralTaskItem } from '../GeneralTaskItem';
 import { ItemControls } from './ItemControls';
-import { Task } from '@/integrations/supabase/types/general-tasks.types'; // Updated import
+import { Task } from '@/types/task';
 import { useNavigate } from 'react-router-dom';
 
 interface PriorityListItemProps {
-  item: PriorityItem;
+  item: Task;
   index: number;
   onTaskClick: (taskId: string) => void;
   onComplete: () => void;
@@ -36,10 +35,10 @@ export const PriorityListItem = ({
   }, [index]);
 
   const handleClick = () => {
-    if (item.data.client_id) {
-      navigate(`/client/${item.data.client_id}`);
+    if (item.client_id) {
+      navigate(`/client/${item.client_id}`);
     } else {
-      onTaskClick(item.data.id);
+      onTaskClick(item.id);
     }
   };
 
@@ -58,25 +57,8 @@ export const PriorityListItem = ({
   };
 
   // Convert PriorityItem to Task format for GeneralTaskItem
-  const convertToTaskFormat = (): Task => {
-    return {
-      id: item.data.id,
-      title: item.data.title,
-      description: item.data.description || null,
-      client_id: item.data.client_id || null,
-      client: item.data.client || null,
-      due_date: item.data.due_date || null,
-      urgent: item.data.urgent,
-      status: item.data.status as "incomplete" | "completed" || "incomplete",
-      completed_at: item.data.completed_at || null,
-      category: item.data.category || null,
-      type: item.type === "next_step" ? "next_step" : "task",
-      // Removing source_table as it's not in the updated Task type
-    };
-  };
-
   return (
-    <div 
+    <div
       className={`relative transition-all duration-500 transform ${
         isVisible 
           ? 'opacity-100 scale-100 max-h-96' 
@@ -96,10 +78,7 @@ export const PriorityListItem = ({
         className="transition-all duration-300 transform hover:scale-[1.01] hover:shadow-md rounded-lg cursor-pointer"
         onClick={handleClick}
       >
-        <GeneralTaskItem 
-          task={convertToTaskFormat() as any} 
-          isClientTask={!!item.data.client_id}
-        />
+        <GeneralTaskItem task={item as any} isClientTask={!!item.client_id} />
       </div>
     </div>
   );

--- a/src/components/crm/priority-actions/hooks/taskTypes.ts
+++ b/src/components/crm/priority-actions/hooks/taskTypes.ts
@@ -1,51 +1,54 @@
 
 import { supabase } from '@/lib/supabaseClient';
-import { TaskType } from '@/types/task';
+import { Task, TaskPriority, TaskStatus } from '@/types/task';
 
-export { TaskType } from '@/types/task';
+export type PriorityItem = Task;
 
-export interface Task {
+export interface SupabaseTaskRow {
   id: string;
   title: string;
-  description?: string | null;
-  client_id?: number | null;
-  client?: { name: string } | null;
-  due_date?: string | null;
+  description: string | null;
+  category: string | null;
+  status: TaskStatus | 'incomplete';
+  due_date: string | null;
+  created_at: string | null;
+  updated_at: string | null;
   urgent: boolean;
-  status?: string;
+  client_id: number | null;
+  created_by: string | null;
+  updated_by: string | null;
   completed_at?: string | null;
-  category?: string | null;
-  type: TaskType;
-  source_table?: 'general_tasks' | 'client_next_steps';
+  priority?: TaskPriority | null;
+  notes?: string | null;
+  next_due_date?: string | null;
+  clients?: { name: string } | null;
 }
 
-// Define the priority item interface that's used across components
-export interface PriorityItem {
-  type: TaskType;
-  data: {
-    id: string;
-    title: string;
-    description?: string | null;
-    client_id?: number | null;
-    client?: { name: string } | null;
-    client_name?: string | null;
-    category?: string | null;
-    due_date?: string | null;
-    next_due_date?: string | null;
-    urgent: boolean;
-    status?: string;
-    notes?: string | null;
-    completed_at?: string | null;
+export const mapTaskRowToTask = (row: SupabaseTaskRow): Task => {
+  const priority = row.priority ?? (row.urgent ? 'urgent' : 'normal');
+
+  return {
+    id: row.id,
+    title: row.title,
+    description: row.description,
+    category: row.category,
+    status: (row.status ?? 'incomplete') as TaskStatus,
+    due_date: row.due_date,
+    next_due_date: row.next_due_date ?? row.due_date,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    completed_at: row.completed_at ?? null,
+    client_id: row.client_id ?? undefined,
+    client: row.clients ?? null,
+    client_name: row.clients?.name ?? null,
+    created_by: row.created_by ?? null,
+    updated_by: row.updated_by ?? null,
+    priority,
+    urgent: priority === 'urgent' ? true : row.urgent,
+    notes: row.notes ?? row.description ?? null
   };
-}
-
-// Helper for accessing the appropriate table based on task type
-export const getTaskTable = (sourceTable: 'general_tasks' | 'client_next_steps') => {
-  return supabase.from(sourceTable);
 };
 
-// Export a reference to the tables for backward compatibility
 export const tasksTable = {
-  general: () => supabase.from('general_tasks'),
-  nextSteps: () => supabase.from('client_next_steps')
+  unified: () => supabase.from('tasks')
 };

--- a/src/components/crm/priority-actions/hooks/useCompletionStatus.ts
+++ b/src/components/crm/priority-actions/hooks/useCompletionStatus.ts
@@ -2,7 +2,7 @@ import logger from '@/utils/logger';
 
 import { supabase } from '@/lib/supabaseClient';
 import { toast } from '@/hooks/use-toast';
-import { PriorityItem } from './usePriorityData';
+import { Task } from '@/types/task';
 import { useQueryManager } from '@/hooks/useQueryManager';
 import { useState } from 'react';
 
@@ -10,7 +10,7 @@ export const useCompletionStatus = () => {
   const { invalidateTaskQueries } = useQueryManager();
   const [processing, setProcessing] = useState(false);
 
-  const handleCompletedChange = async (item: PriorityItem, completed: boolean) => {
+  const handleCompletedChange = async (task: Task, completed: boolean) => {
     // Prevent multiple simultaneous updates
     if (processing) {
       logger.info('Already processing a completion change, ignoring request');
@@ -19,12 +19,11 @@ export const useCompletionStatus = () => {
     
     try {
       setProcessing(true);
-      logger.info(`Updating item (${item.type}:${item.data.id}) completed status to: ${completed}`);
+      logger.info(`Updating task (${task.id}) completed status to: ${completed}`);
       
       // Add timestamp for debugging
       const timestamp = new Date().toISOString();
-      const itemId = item.data.id;
-      const clientId = item.data.client_id;
+      const itemId = task.id;
       
       // Update the database with the new status
       const { error } = await supabase

--- a/src/components/crm/priority-actions/hooks/useItemDeletion.ts
+++ b/src/components/crm/priority-actions/hooks/useItemDeletion.ts
@@ -1,7 +1,7 @@
 import logger from '@/utils/logger';
 
 import { toast } from '@/hooks/use-toast';
-import { PriorityItem } from './usePriorityData';
+import { Task } from '@/types/task';
 import { useState } from 'react';
 import { useTaskDeletion } from '@/hooks/useTaskDeletion';
 import { useQueryClient } from '@tanstack/react-query';
@@ -31,17 +31,17 @@ export const useItemDeletion = () => {
     ]);
   });
 
-  const handleDelete = async (item: PriorityItem) => {
+  const handleDelete = async (task: Task) => {
     if (isDeleting) {
       return false;
     }
-    
+
     setIsDeleting(true);
-    
+
     try {
-      const itemId = item.data.id;
-      logger.info(`[ITEM_DELETION] Deleting item ${item.type}:${itemId}`);
-      
+      const itemId = task.id;
+      logger.info(`[ITEM_DELETION] Deleting task ${itemId}`);
+
       // Format task for deletion
       const taskToDelete = {
         id: String(itemId)
@@ -55,14 +55,14 @@ export const useItemDeletion = () => {
       }
       
       // If this was a client task, refresh client data
-      if (item.data.client_id) {
+      if (task.client_id) {
         await Promise.all([
-          queryClient.refetchQueries({ 
-            queryKey: queryKeys.clients.detail(item.data.client_id) 
+          queryClient.refetchQueries({
+            queryKey: queryKeys.clients.detail(task.client_id)
           }),
-          
-          queryClient.refetchQueries({ 
-            queryKey: queryKeys.tasks.clientItems(item.data.client_id) 
+
+          queryClient.refetchQueries({
+            queryKey: queryKeys.tasks.clientItems(task.client_id)
           })
         ]);
       }

--- a/src/components/crm/priority-actions/hooks/usePriorityData.ts
+++ b/src/components/crm/priority-actions/hooks/usePriorityData.ts
@@ -3,7 +3,8 @@ import logger from '@/utils/logger';
 import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { supabase, logResponse } from "@/lib/supabaseClient";
-import { PriorityItem } from "./taskTypes";
+import { mapTaskRowToTask, PriorityItem, SupabaseTaskRow } from "./taskTypes";
+import { Task } from "@/types/task";
 import { queryKeys } from "@/lib/queryKeys";
 
 // Re-export the PriorityItem type to make it available to components
@@ -20,7 +21,7 @@ export const usePriorityData = () => {
   // Fetches all incomplete tasks
   const { data: tasksData, refetch: refetchTasks } = useQuery({
     queryKey: queryKeys.tasks.unified(),
-    queryFn: async () => {
+    queryFn: async (): Promise<Task[]> => {
       logger.info("Fetching incomplete tasks...");
       setIsLoading(true);
 
@@ -50,7 +51,8 @@ export const usePriorityData = () => {
           logger.info("No tasks returned from the database");
         }
         
-        return response.data || [];
+        const rows = (response.data || []) as SupabaseTaskRow[];
+        return rows.map(mapTaskRowToTask);
       } catch (error) {
         logger.error("Error in fetchTasks:", error);
         setIsLoading(false);
@@ -63,72 +65,27 @@ export const usePriorityData = () => {
     refetchOnWindowFocus: true,
   });
 
-  // Map task data to the unified PriorityItem format
-  const mapTasksToPriorityItems = (): PriorityItem[] => {
-    if (!tasksData) {
-      logger.info("No task data available to map");
-      return [];
-    }
-    
-    logger.info(`Mapping ${tasksData.length} tasks to priority items`);
-
-    return tasksData.map((task) => {
-      // Handle tasks with client relation
-      if (task.client_id) {
-        return {
-          type: "next_step", // Changed from "next-step" to "next_step" to match the type definition
-          data: {
-            id: task.id,
-            title: task.title,
-            description: task.description,
-            client_id: task.client_id,
-            client_name: task.clients?.name || null,
-            category: task.category,
-            due_date: task.due_date,
-            urgent: task.urgent,
-            status: task.status,
-          },
-        };
-      }
-
-      // Handle general tasks
-      return {
-        type: "task",
-        data: {
-          id: task.id,
-          title: task.title,
-          description: task.description,
-          category: task.category,
-          due_date: task.due_date,
-          urgent: task.urgent,
-          status: task.status,
-        },
-      };
-    });
-  };
-
-  // Sort priority items by urgency, then by due date
-  const sortPriorityItems = (items: PriorityItem[]): PriorityItem[] => {
+  // Sort tasks by urgency, then by due date
+  const sortTasks = (items: Task[]): Task[] => {
     return [...items].sort((a, b) => {
-      // First sort by urgency
-      if (a.data.urgent && !b.data.urgent) return -1;
-      if (!a.data.urgent && b.data.urgent) return 1;
+      if ((a.urgent ?? false) && !(b.urgent ?? false)) return -1;
+      if (!(a.urgent ?? false) && (b.urgent ?? false)) return 1;
 
-      // Then sort by due date (if both have one)
-      if (a.data.due_date && b.data.due_date) {
-        return new Date(a.data.due_date).getTime() - new Date(b.data.due_date).getTime();
+      const aDue = a.due_date || a.next_due_date;
+      const bDue = b.due_date || b.next_due_date;
+
+      if (aDue && bDue) {
+        return new Date(aDue).getTime() - new Date(bDue).getTime();
       }
 
-      // If only one has a due date, prioritize it
-      if (a.data.due_date && !b.data.due_date) return -1;
-      if (!a.data.due_date && b.data.due_date) return 1;
+      if (aDue && !bDue) return -1;
+      if (!aDue && bDue) return 1;
 
       return 0;
     });
   };
 
-  // Get all priority items and sort them
-  const priorityItems = sortPriorityItems(mapTasksToPriorityItems());
+  const priorityItems: PriorityItem[] = sortTasks(tasksData || []);
   logger.info(`Total priority items after sorting: ${priorityItems.length}`);
 
   // Refetch all data

--- a/src/components/crm/priority-actions/hooks/useTasks.ts
+++ b/src/components/crm/priority-actions/hooks/useTasks.ts
@@ -3,9 +3,9 @@ import logger from '@/utils/logger';
 import { useTasksQuery } from './useTasksQuery';
 import { useTasksMutations } from './useTasksMutations';
 import { useQueryManager } from '@/hooks/useQueryManager';
-import { Task } from './taskTypes';
+import { Task } from '@/types/task';
 
-export type { Task } from './taskTypes';
+export type { Task } from '@/types/task';
 
 export const useTasks = (category?: string, showCompleted = false) => {
   const { 

--- a/src/components/crm/priority-actions/hooks/useTasksMutations.ts
+++ b/src/components/crm/priority-actions/hooks/useTasksMutations.ts
@@ -2,7 +2,6 @@ import logger from '@/utils/logger';
 
 import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Task, tasksTable } from './taskTypes';
 import { supabase, logQuery } from '@/lib/supabaseClient';
 import { toast } from '@/hooks/use-toast';
 
@@ -17,19 +16,12 @@ export const useTasksMutations = () => {
       setIsUpdating(true);
       logQuery('tasks', 'updating completion');
       
-      let table;
-      // Determine which table to update based on the task ID format
-      if (args.taskId.startsWith('next-step-')) {
-        table = tasksTable.nextSteps();
-      } else {
-        table = tasksTable.general();
-      }
-      
-      const { data, error } = await table
+      const { data, error } = await supabase
+        .from('tasks')
         .update({
           status: args.completed ? 'completed' : 'incomplete'
         })
-        .eq('id', args.taskId.replace('next-step-', ''))
+        .eq('id', args.taskId)
         .select();
 
       if (error) {
@@ -65,17 +57,10 @@ export const useTasksMutations = () => {
       setIsUpdating(true);
       logQuery('tasks', 'updating urgency');
       
-      let table;
-      // Determine which table to update based on the task ID format
-      if (args.taskId.startsWith('next-step-')) {
-        table = tasksTable.nextSteps();
-      } else {
-        table = tasksTable.general();
-      }
-      
-      const { data, error } = await table
+      const { data, error } = await supabase
+        .from('tasks')
         .update({ urgent: args.urgent })
-        .eq('id', args.taskId.replace('next-step-', ''))
+        .eq('id', args.taskId)
         .select();
 
       if (error) {
@@ -108,17 +93,10 @@ export const useTasksMutations = () => {
       setIsDeleting(true);
       logQuery('tasks', 'deleting');
       
-      let table;
-      // Determine which table to delete from based on the task ID format
-      if (taskId.startsWith('next-step-')) {
-        table = tasksTable.nextSteps();
-      } else {
-        table = tasksTable.general();
-      }
-      
-      const { error } = await table
+      const { error } = await supabase
+        .from('tasks')
         .delete()
-        .eq('id', taskId.replace('next-step-', ''));
+        .eq('id', taskId);
 
       if (error) {
         logger.error('Error deleting task:', error);

--- a/src/components/crm/priority-actions/hooks/useTasksQuery.ts
+++ b/src/components/crm/priority-actions/hooks/useTasksQuery.ts
@@ -1,7 +1,8 @@
 import logger from '@/utils/logger';
 
 import { useQuery } from '@tanstack/react-query';
-import { Task, tasksTable } from './taskTypes';
+import { Task } from '@/types/task';
+import { mapTaskRowToTask, tasksTable, SupabaseTaskRow } from './taskTypes';
 import { supabase, logQuery } from '@/lib/supabaseClient';
 import { toast } from '@/hooks/use-toast';
 
@@ -12,8 +13,8 @@ export const useTasksQuery = (category?: string, showCompleted = false) => {
     logger.info(`Fetching tasks with category: ${category}, showCompleted: ${showCompleted}`);
 
     try {
-      // Prepare query builder for general_tasks table
-      let query = tasksTable.general().select('*, clients(name)');
+      // Prepare query builder for the unified tasks table
+      let query = tasksTable.unified().select('*, clients(name)');
 
       // Apply completed filter
       if (showCompleted) {
@@ -45,13 +46,8 @@ export const useTasksQuery = (category?: string, showCompleted = false) => {
       logger.info(`Fetched ${data?.length} tasks`);
       
       // Map the returned data to our Task interface
-      const tasks = (data || []).map(task => ({
-        ...task,
-        type: 'task' as const,
-        source_table: 'general_tasks' as const
-      }));
-      
-      return tasks;
+      const rows = (data || []) as SupabaseTaskRow[];
+      return rows.map(mapTaskRowToTask);
     } catch (e) {
       logger.error('Exception in fetchTasks:', e);
       return [];

--- a/src/components/crm/priority-actions/hooks/useUrgencyStatus.ts
+++ b/src/components/crm/priority-actions/hooks/useUrgencyStatus.ts
@@ -2,27 +2,27 @@ import logger from '@/utils/logger';
 
 import { supabase } from '@/lib/supabaseClient';
 import { toast } from '@/hooks/use-toast';
-import { PriorityItem } from './usePriorityData';
+import { Task } from '@/types/task';
 import { useQueryManager } from '@/hooks/useQueryManager';
 
 export const useUrgencyStatus = () => {
   const { invalidateTaskQueries } = useQueryManager();
 
-  const handleUrgentChange = async (item: PriorityItem, checked: boolean) => {
+  const handleUrgentChange = async (task: Task, checked: boolean) => {
     try {
       // Add timestamp for debugging
       const timestamp = new Date().toISOString();
-      const itemId = item.data.id;
-      const clientId = item.data.client_id;
+      const itemId = task.id;
       
-      logger.info(`Updating urgency for ${item.type}:${itemId} to ${checked} at ${timestamp}`);
+      logger.info(`Updating urgency for task:${itemId} to ${checked} at ${timestamp}`);
       
       // Update database
       const { error } = await supabase
         .from('tasks')
-        .update({ 
+        .update({
           urgent: checked,
-          updated_at: timestamp 
+          priority: checked ? 'urgent' : 'normal',
+          updated_at: timestamp
         })
         .eq('id', itemId);
 

--- a/src/components/strategy/components/IdeaTaskManager.tsx
+++ b/src/components/strategy/components/IdeaTaskManager.tsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import { TaskDialog } from "@/components/crm/priority-actions/TaskDialog";
 import { CreateTaskDialog } from "./CreateTaskDialog";
-import { TaskType } from "@/types/task";
+import { TaskPriority } from "@/types/task";
 
 interface IdeaTaskManagerProps {
   category: string;
@@ -17,6 +17,14 @@ export const IdeaTaskManager = ({ category, onTaskSaved }: IdeaTaskManagerProps)
     type: string;
   } | null>(null);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+
+  const mapPriority = (priority: string): TaskPriority => {
+    const normalized = priority.toLowerCase();
+    if (normalized === 'urgent') return 'urgent';
+    if (normalized === 'high') return 'high';
+    if (normalized === 'low') return 'low';
+    return 'normal';
+  };
 
   const handleCreateTask = (idea: { suggestion: string; priority: string; type: string }) => {
     setSelectedIdea(idea);
@@ -42,15 +50,17 @@ export const IdeaTaskManager = ({ category, onTaskSaved }: IdeaTaskManagerProps)
           title: selectedIdea.suggestion,
           description: `Type: ${selectedIdea.type}\nPriority: ${selectedIdea.priority}`,
           category: category,
-          status: 'incomplete',
+          status: 'pending',
           due_date: null, // Initially null - when a due date is added, it will appear in Priority Actions
           created_at: new Date().toISOString(),
           updated_at: new Date().toISOString(),
-          urgent: selectedIdea.priority === 'High', // Set urgent based on priority
+          priority: mapPriority(selectedIdea.priority),
+          urgent: mapPriority(selectedIdea.priority) === 'urgent',
           client_id: null,
           updated_by: null,
           created_by: null,
-          type: 'idea' as TaskType // Cast to TaskType to ensure compatibility
+          notes: null,
+          next_due_date: null
         } : null}
         onSaved={() => {
           setIsTaskDialogOpen(false);

--- a/src/components/strategy/hooks/useGeneralTasks.ts
+++ b/src/components/strategy/hooks/useGeneralTasks.ts
@@ -2,13 +2,14 @@ import logger from '@/utils/logger';
 
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/lib/supabaseClient";
-import { Task } from "@/hooks/useTaskDeletion";
+import { Task } from "@/types/task";
 import { queryKeys } from "@/lib/queryKeys";
+import { mapTaskRowToTask, SupabaseTaskRow } from "@/components/crm/priority-actions/hooks/taskTypes";
 
 export const useGeneralTasks = (category: string, refreshTrigger: number) => {
   return useQuery({
     queryKey: [...queryKeys.tasks.general(), category, refreshTrigger],
-    queryFn: async () => {
+    queryFn: async (): Promise<Task[]> => {
       logger.info('Fetching tasks for category:', category);
 
       // Fetch tasks from the unified tasks table
@@ -25,15 +26,8 @@ export const useGeneralTasks = (category: string, refreshTrigger: number) => {
       logger.info('Strategy - fetched tasks:', tasks?.length);
       
       // Format tasks for display
-      const formattedTasks = tasks?.map(task => ({
-        ...task,
-        type: 'task' as const,
-        source_table: 'tasks',
-        next_due_date: task.due_date, // Map due_date to next_due_date for backward compatibility
-        notes: task.description, // Map description to notes for backward compatibility
-        client_name: task.clients?.name, // Add client_name for compatibility 
-        original_data: task // Store the full original object for reference
-      })) || [];
+      const rows = (tasks || []) as SupabaseTaskRow[];
+      const formattedTasks = rows.map(mapTaskRowToTask);
 
       logger.info('Strategy - formatted tasks count:', formattedTasks.length);
       return formattedTasks;

--- a/src/hooks/useTaskDeletion.ts
+++ b/src/hooks/useTaskDeletion.ts
@@ -5,7 +5,7 @@ import { supabase } from '@/lib/supabaseClient';
 import { toast } from '@/hooks/use-toast';
 import { useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/queryKeys';
-import { Task, TaskType } from '@/types/task';
+import { Task } from '@/types/task';
 
 // Re-export the Task type for backward compatibility
 export type { Task } from '@/types/task';

--- a/src/integrations/supabase/types/general-tasks.types.ts
+++ b/src/integrations/supabase/types/general-tasks.types.ts
@@ -1,5 +1,5 @@
 
-import { Task as CoreTask, TaskType } from '@/types/task';
+import { Task as CoreTask, TaskPriority, TaskStatus } from '@/types/task';
 
 export type GeneralTaskRow = {
   id: string;
@@ -18,7 +18,7 @@ export type GeneralTaskRow = {
   completed_at: string | null;
   notes: string | null;
   client_name?: string | null;
-  type?: TaskType; // Use TaskType from the core definition
+  priority?: TaskPriority | null;
 }
 
 export type GeneralTaskInsert = Omit<GeneralTaskRow, 'id' | 'created_at' | 'updated_at'> & {
@@ -48,7 +48,7 @@ export const taskToGeneralTaskRow = (task: CoreTask): GeneralTaskRow => {
     completed_at: task.status === 'completed' ? task.updated_at : null,
     notes: task.description || null,
     client_name: task.client?.name || task.client_name || null,
-    type: task.type || 'task'
+    priority: task.priority
   };
 };
 
@@ -72,7 +72,7 @@ export const generalTaskRowToTask = (row: GeneralTaskRow): CoreTask => {
     completed_at: row.completed_at,
     client_name: row.client_name,
     client: row.client_name ? { name: row.client_name } : null,
-    type: row.type || 'task'
+    priority: row.priority || (row.urgent ? 'urgent' : 'normal')
   };
 };
 
@@ -84,13 +84,13 @@ export interface Task {
   client?: { name: string } | null;
   due_date?: string | null;
   urgent: boolean;
-  status: "incomplete" | "completed";
+  status: TaskStatus;
   completed_at?: string | null;
   category?: string | null;
   created_at?: string | null;
   updated_at?: string | null;
   created_by?: string | null;
   updated_by?: string | null;
-  type?: TaskType;
+  priority?: TaskPriority;
   source_table?: string;
 }

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -7,7 +7,7 @@
 export type TaskPriority = 'low' | 'normal' | 'high' | 'urgent';
 
 // Task status
-export type TaskStatus = 'pending' | 'in_progress' | 'completed';
+export type TaskStatus = 'pending' | 'in_progress' | 'completed' | 'incomplete';
 
 // Unified Task interface
 export interface Task {
@@ -26,6 +26,8 @@ export interface Task {
   updated_at?: string | null;
   created_by?: string | null;
   updated_by?: string | null;
+  next_due_date?: string | null;
+  notes?: string | null;
 
   // Legacy support for existing data
   urgent?: boolean; // Will map to priority 'urgent' vs 'normal'

--- a/src/types/unified/task.types.ts
+++ b/src/types/unified/task.types.ts
@@ -1,41 +1,14 @@
-// Define a single source of truth for task types
-export type TaskStatus = 'completed' | 'incomplete';
-export type TaskType = 'task' | 'next_step' | 'idea';
+export { Task, TaskPriority, TaskStatus } from '../task';
+
+import { Task, TaskPriority, TaskStatus } from '../task';
+
 export type TaskCategory = 'Marketing' | 'Business Admin' | 'Product Development' | 'Partnerships' | string;
 
-export interface Task {
-  // Core properties
-  id: string;
-  title: string;
-  description: string | null;
-  category: TaskCategory | null;
-  status: TaskStatus;
-  urgent: boolean;
-  
-  // Dates
-  due_date: string | null;
-  created_at: string | null;
-  updated_at: string | null;
-  completed_at: string | null;
-  
-  // Relations
-  client_id: number | null;
-  client?: { name: string } | null;
-  client_name?: string | null;
-  
-  // Metadata
-  created_by: string | null;
-  updated_by: string | null;
-  type: TaskType;
+export interface UnifiedTask extends Task {
   source_table?: 'tasks' | 'general_tasks' | 'client_next_steps';
-  
-  // Backward compatibility
-  notes?: string | null;
-  next_due_date?: string | null;
 }
 
-// Database-specific types
-export type TaskRow = Omit<Task, 'client' | 'client_name' | 'notes' | 'next_due_date' | 'source_table'>;
+export type TaskRow = Omit<UnifiedTask, 'client' | 'client_name' | 'notes' | 'next_due_date' | 'source_table'>;
 
 export type TaskInsert = Omit<TaskRow, 'id' | 'created_at' | 'updated_at' | 'completed_at'> & {
   id?: string;
@@ -46,16 +19,24 @@ export type TaskInsert = Omit<TaskRow, 'id' | 'created_at' | 'updated_at' | 'com
 
 export type TaskUpdate = Partial<TaskInsert>;
 
-// Conversion utilities
-export const convertToUnifiedTask = (source: any): Task => {
+export const convertToUnifiedTask = (source: any): UnifiedTask => {
+  const dueDate = source.due_date || source.next_due_date || null;
+  const priority: TaskPriority = source.priority
+    ? source.priority
+    : source.urgent
+      ? 'urgent'
+      : 'normal';
+
   return {
     id: source.id,
     title: source.title || '',
     description: source.description || source.notes || null,
     category: source.category || null,
-    status: source.status || 'incomplete',
-    urgent: Boolean(source.urgent),
-    due_date: source.due_date || source.next_due_date || null,
+    status: (source.status || 'incomplete') as TaskStatus,
+    urgent: Boolean(source.urgent || priority === 'urgent'),
+    priority,
+    due_date: dueDate,
+    next_due_date: dueDate,
     created_at: source.created_at || null,
     updated_at: source.updated_at || null,
     completed_at: source.completed_at || null,
@@ -64,9 +45,7 @@ export const convertToUnifiedTask = (source: any): Task => {
     client_name: source.client_name || source.client?.name || null,
     created_by: source.created_by || null,
     updated_by: source.updated_by || null,
-    type: source.type || 'task',
-    source_table: source.source_table || 'tasks',
     notes: source.notes || source.description || null,
-    next_due_date: source.next_due_date || source.due_date || null
+    source_table: source.source_table || 'tasks'
   };
 };


### PR DESCRIPTION
## Summary
- unify the core task type by removing the TaskType variant field and adding shared metadata
- refactor CRM priority hooks and components to operate on a single Task shape and simplify the list logic
- align strategy task fetching and idea conversion with the unified tasks table utilities

## Testing
- npm run build *(fails: vite: not found in container PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68e518b4ef98832ab908aa22ffe68995